### PR TITLE
Ajout du fichier htoprc

### DIFF
--- a/htoprc
+++ b/htoprc
@@ -1,0 +1,22 @@
+# Beware! This file is rewritten every time htop exits.
+# The parser is also very primitive, and not human-friendly.
+# (I know, it's in the todo list).
+fields=0 48 17 18 38 39 40 2 46 47 49 1 
+sort_key=46
+sort_direction=1
+hide_threads=0
+hide_kernel_threads=0
+hide_userland_threads=0
+shadow_other_users=0
+highlight_base_name=1
+highlight_megabytes=1
+highlight_threads=1
+tree_view=1
+header_margin=1
+detailed_cpu_time=1
+color_scheme=0
+delay=15
+left_meters=AllCPUs Memory Swap 
+left_meter_modes=1 1 1 
+right_meters=Tasks LoadAverage Uptime 
+right_meter_modes=2 2 2 


### PR DESCRIPTION
Ajout du fichier htoprc afin de faciliter la visualisation des informations dans Htop.

Testé avec htop 0.8.3 - Ubuntu 10.04.4 LTS.
